### PR TITLE
fix(wx.getAccountInfoSync): fix miniProgram property spelling

### DIFF
--- a/src/api/open.js
+++ b/src/api/open.js
@@ -2,7 +2,7 @@ const _ = require('./utils')
 
 module.exports = {
     getAccountInfoSync: _.mockSync({
-        miniprogram: {appId: 'wx4f4bc4dec97d474b'},
+        miniProgram: {appId: 'wx4f4bc4dec97d474b'},
     }),
     chooseAddress(options = {}) {
         _.runInAsync(options, {


### PR DESCRIPTION
修复 `wx.getAccountInfoSync` 接口返回 [`miniProgram` 字段](https://developers.weixin.qq.com/miniprogram/dev/api/open-api/account-info/wx.getAccountInfoSync.html)为 `undefined` 的问题

<img width="495" alt="image" src="https://user-images.githubusercontent.com/8225666/154793950-ac33bab7-b695-4405-b653-d652d2220467.png">
